### PR TITLE
Race condition when setting delegate form react-native wrapper

### DIFF
--- a/Sources/Grovs/Grovs.swift
+++ b/Sources/Grovs/Grovs.swift
@@ -14,10 +14,12 @@ public protocol GrovsDelegate {
 
 /// A class representing Grovs SDK.
 public class Grovs {
+    private static var _delegate: GrovsDelegate?
 
     /// The delegate to receive callbacks from the SDK.
     public static var delegate: GrovsDelegate? {
         set {
+            _delegate = newValue
             manager?.delegate = newValue
         }
 
@@ -30,7 +32,11 @@ public class Grovs {
     private static var APIKey: String!
 
     /// The manager handling Grovs functionality.
-    private static var manager: GrovsManager?
+    private static var manager: GrovsManager? {
+        didSet {
+            manager?.delegate = _delegate
+        }
+    }
 
     // MARK: Public methods
 


### PR DESCRIPTION
There is race condition, as react-native wrapper sets delegate directly using Grovs.delegate. Sometimes `private static var manager: GrovsManager?` is nil at the moment of setting delegate.

This PR fixes this issue by storing delegate in private variable and try to set it once manager is present. I consider it rather a hacky way of solving this issue, but it is sufficient at the moment. To proper resolve it there is probably need to refactor this logic (like having delegate queue, or don't use static variables and let RN wrapper handle own instance)

Reminder:
There is need to bump Grovs-iOS version and update it in RN wrapper `.podspec` file